### PR TITLE
Added a link to scim.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ From below wikipedia article:
 
 ## Tools & Library
 - bridge between SCIM endpoint and non-scim apps: https://github.com/jelhub/scimgateway
+- SCIM Playground: https://scim.dev
 
 ## Miscs
 - SCIM over pub-sub NATS : https://elshaug.xyz/docs/scim-stream


### PR DESCRIPTION
Perhaps useful. Full disclosure: [scim.dev](https://scim.dev) is mine.